### PR TITLE
Feat/reduce view footprint in the string

### DIFF
--- a/Sources/Extensions/String.toPJString(in).swift
+++ b/Sources/Extensions/String.toPJString(in).swift
@@ -10,12 +10,8 @@ extension String {
     public func toPJString(in view: View) -> NSAttributedString {
         let defaultFont = Font()
         let font = view.getFont() ?? defaultFont
-        let parentWidth = getTotalWidth(in: view)
+        let parentWidth = view.frame.width
 
         return toPJString(fittingWidth: parentWidth, font: font)
-    }
-
-    func getTotalWidth(in view: View) -> CGFloat {
-        return view.frame.width
     }
 }

--- a/Sources/Extensions/String.toPJString(in).swift
+++ b/Sources/Extensions/String.toPJString(in).swift
@@ -1,0 +1,21 @@
+import Foundation
+
+extension String {
+
+    @available(
+        *, deprecated,
+        renamed: "toPJString(fittingWidth:font:)",
+        message: "This method requires too much information and will not be available from v1.0"
+    )
+    public func toPJString(in view: View) -> NSAttributedString {
+        let defaultFont = Font()
+        let font = view.getFont() ?? defaultFont
+        let parentWidth = getTotalWidth(in: view)
+
+        return toPJString(fittingWidth: parentWidth, font: font)
+    }
+
+    func getTotalWidth(in view: View) -> CGFloat {
+        return view.frame.width
+    }
+}

--- a/Sources/Extensions/Typealias.swift
+++ b/Sources/Extensions/Typealias.swift
@@ -1,0 +1,9 @@
+#if canImport(UIKit)
+import UIKit
+public typealias Font = UIFont
+public typealias View = UIView
+#elseif canImport(AppKit)
+import AppKit
+public typealias Font = NSFont
+public typealias View = NSView
+#endif

--- a/Sources/Extensions/View.getFont.swift
+++ b/Sources/Extensions/View.getFont.swift
@@ -1,12 +1,4 @@
-#if canImport(UIKit)
-import UIKit
-public typealias Font = UIFont
-public typealias View = UIView
-#elseif canImport(AppKit)
-import AppKit
-public typealias Font = NSFont
-public typealias View = NSView
-#endif
+import Foundation
 
 internal extension View {
     func getFont() -> Font? { 

--- a/Sources/PersianJustify.swift
+++ b/Sources/PersianJustify.swift
@@ -24,7 +24,20 @@ fileprivate let forbiddenExtendableCharacters = ["ا", "د", "ذ", "ر", "ز", "
 
 // MARK: - Usage using toPJString function
 extension String {
-    
+
+    @available(
+        *, deprecated,
+        renamed: "toPJString(fittingWidth:font:)",
+        message: "This method requires too much information and will not be available from v1.0"
+    )
+    public func toPJString(in view: View) -> NSAttributedString {
+        let defaultFont = Font()
+        let font = view.getFont() ?? defaultFont
+        let parentWidth = getTotalWidth(in: view)
+
+        return toPJString(fittingWidth: parentWidth, font: font)
+    }
+
     public func toPJString(fittingWidth parentWidth: CGFloat, font: Font = Font()) -> NSAttributedString {
         let defaultAttributedTest = NSAttributedString(string: self)
         //                return defaultAttributedTest // MARK: Uncomment to see the unjustified text

--- a/Sources/PersianJustify.swift
+++ b/Sources/PersianJustify.swift
@@ -25,16 +25,13 @@ fileprivate let forbiddenExtendableCharacters = ["ا", "د", "ذ", "ر", "ز", "
 // MARK: - Usage using toPJString function
 extension String {
     
-    public func toPJString(in view: View) -> NSAttributedString {
+    public func toPJString(fittingWidth parentWidth: CGFloat, font: Font = Font()) -> NSAttributedString {
         let defaultAttributedTest = NSAttributedString(string: self)
         //                return defaultAttributedTest // MARK: Uncomment to see the unjustified text
         if isEmpty { return defaultAttributedTest }
-        let defaultFont = Font()
-        let font = view.getFont() ?? defaultFont
         let final = NSMutableAttributedString(string: "")
         let doubleNextLine = nextLineCharacter.description + nextLineCharacter.description
         let allLines = replacingOccurrences(of:doubleNextLine, with: nextLineCharacter.description).getWords(separator: nextLineCharacter)
-        let parentWidth = getTotalWidth(in: view)
         for i in 0..<allLines.count {
             let words = allLines[i].split(separator: spaceCharacter).compactMap({$0.description})
             var currentLineWords: [String] = []

--- a/Sources/PersianJustify.swift
+++ b/Sources/PersianJustify.swift
@@ -25,19 +25,6 @@ fileprivate let forbiddenExtendableCharacters = ["ا", "د", "ذ", "ر", "ز", "
 // MARK: - Usage using toPJString function
 extension String {
 
-    @available(
-        *, deprecated,
-        renamed: "toPJString(fittingWidth:font:)",
-        message: "This method requires too much information and will not be available from v1.0"
-    )
-    public func toPJString(in view: View) -> NSAttributedString {
-        let defaultFont = Font()
-        let font = view.getFont() ?? defaultFont
-        let parentWidth = getTotalWidth(in: view)
-
-        return toPJString(fittingWidth: parentWidth, font: font)
-    }
-
     public func toPJString(fittingWidth parentWidth: CGFloat, font: Font = Font()) -> NSAttributedString {
         let defaultAttributedTest = NSAttributedString(string: self)
         //                return defaultAttributedTest // MARK: Uncomment to see the unjustified text
@@ -126,10 +113,6 @@ private extension String {
     
     func getWords(separator: Character) -> [String] {
         return split(separator: separator).compactMap({$0.description})
-    }
-
-    func getTotalWidth(in view: View) -> CGFloat {
-        return view.frame.width
     }
     
     func getWordWidth(font: Font, isRequiredSpace: Bool = true) -> CGFloat {


### PR DESCRIPTION
We need no properties of the `View` except for its `width` and (***preferably***) its current `font`. So there should be no force to pass in a view as an argument.

I have also added a backward-compatible API for those who are currently using the package until the next major release and the drop of the support.